### PR TITLE
Prevent matplotlib selecting the PyQt API instead of PySide2

### DIFF
--- a/src/Mod/Plot/Plot.py
+++ b/src/Mod/Plot/Plot.py
@@ -26,11 +26,20 @@ import FreeCAD
 import PySide
 from PySide import QtCore, QtGui
 from distutils.version import LooseVersion as V
+import sys
 
 try:
     import matplotlib
     matplotlib.use('Qt5Agg')
-    import matplotlib.pyplot as plt
+    
+    # Force matplotlib to use PySide backend by temporarily unloading PyQt
+    if 'PyQt5.QtCore' in sys.modules:
+        del sys.modules['PyQt5.QtCore']
+        import matplotlib.pyplot as plt
+        import PyQt5.QtCore
+    else:
+        import matplotlib.pyplot as plt
+
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg as FigureCanvas
     from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT as NavigationToolbar
 


### PR DESCRIPTION
Hi, I was testing pull request https://github.com/FreeCAD/FreeCAD/pull/4971 and just had one issue that might be specific to my system (Ubuntu 20.04). 

This is the same problem I had previously with the plot workbench and described and fixed in the following old pull request in the plot workbench: https://github.com/FreeCAD/freecad.plot/pull/11

The present pull request applies a similar fix to the one used there.

